### PR TITLE
54 Remove package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+package-lock.json
 dist
 dist-ssr
 *.local


### PR DESCRIPTION
Just added `package-lock.json` into `.gitignore` since it was already deleted in one of the pull requests